### PR TITLE
[PATCH] phpunit and test bootstrap refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -1,18 +1,12 @@
 <?php
 
-require_once $_SERVER['SYMFONY'].'/Symfony/Component/ClassLoader/UniversalClassLoader.php';
+if (!($loader = @include __DIR__ . '/../vendor/autoload.php')) {
+    die(<<<'EOT'
+You must set up the project dependencies, run the following commands:
+wget http://getcomposer.org/composer.phar
+php composer.phar install
+EOT
+    );
+}
 
-use Symfony\Component\ClassLoader\UniversalClassLoader;
-
-$loader = new UniversalClassLoader();
-$loader->registerNamespace('Symfony', $_SERVER['SYMFONY']);
-$loader->register();
-
-spl_autoload_register(function($class)
-{
-    if (0 === strpos($class, 'Overblog\\MediaWiki\\')) {
-        $path = implode('/', array_slice(explode('\\', $class), 2)).'.php';
-        require_once __DIR__.'/../'.$path;
-        return true;
-    }
-});
+return $loader;

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,10 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.7",
+        "symfony/class-loader": "~2.7"
+    },
     "target-dir": "Overblog/MediaWiki",
     "autoload": {
         "psr-0": {"Overblog\\MediaWiki": ""}


### PR DESCRIPTION
Hi, 

I’m working on migrating MediaWiki wikitext into another syntax, maybe Markdown, and found this project. While trying it, I’ve found that I couldn’t load and run phpunit right away, this is what this patch does.

The code looks great and the tests makes sense, but I couldn’t find where to start to use this library with my own content (i.e. couldn’t guess the [right MW API call](https://www.mediawiki.org/wiki/API:Data_formats)). Looking up the docs at [WikiDom Specification](https://www.mediawiki.org/wiki/VisualEditor/WikiDom_Specification) says its deprecated and something called [Parsoid](https://www.mediawiki.org/wiki/Parsoid) instead. But I’m curious about what you ended up doing with all this.

Did you guys abandon the project?
Anything written about the use of this project at all?

I was wondering what could be done to use it.

Hope this patch helps.
